### PR TITLE
fixed naming convention for card-product

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -6,5 +6,3 @@
 @import "card";
 @import "footer";
 @import "index-card";
-@import "card-product"
-


### PR DESCRIPTION
Fixed naming convention, two cards were using the same class name, deleted import from index