### PR TITLE
changed button from show to edit for personal NFTs on profile page

### DIFF
--- a/app/views/nfts/_simple_card.html.erb
+++ b/app/views/nfts/_simple_card.html.erb
@@ -11,7 +11,7 @@
           <span>$&ensp;</span><%=nft.price %>
         </div>
         <div class="buttonShow">
-          <%= link_to 'Show', nft_path(nft), class:"btn btn-light" %>
+          <%= link_to link_name, some_path, class:"btn btn-light" %>
         </div>
       </div>
     </div>

--- a/app/views/nfts/index.html.erb
+++ b/app/views/nfts/index.html.erb
@@ -4,7 +4,7 @@
   <div class="row">
     <%= render "nfts/placeholder_card" %>
     <% @nfts.each do |nft| %>
-    <%= render "nfts/simple_card", nft: nft %>
+    <%= render "nfts/simple_card", nft: nft, some_path: nft_path(nft), link_name: 'Show' %>
     <% end %>
   </div>
   <br>

--- a/app/views/rentals/index.html.erb
+++ b/app/views/rentals/index.html.erb
@@ -3,13 +3,13 @@
     <div class="rentals_index">
       <h5>Your Rentals</h5>
         <% @rentals.each do |rental| %>
-        <%= render "nfts/simple_card", nft: rental.nft %>
+        <%= render "nfts/simple_card", nft: rental.nft, link_name: 'Show', some_path: nft_path(rental.nft) %>
         <% end %>
     </div>
     <div class="user-nfts">
       <h5>Your NFTs</h5>
       <% @nfts.each do |nft| %>
-      <%= render "nfts/simple_card", nft: nft %>
+      <%= render "nfts/simple_card", nft: nft, link_name: 'Edit', some_path: edit_nft_path(nft) %>
       <% end %>
     </div>
   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Rental.destroy_all
 Nft.destroy_all
 User.destroy_all
-Rental.destroy_all
 
 user_1 = User.create(username: "Pedro", email: "pedro@lewagon.com", password: "12345678")
 user_2 = User.create(username: "John", email: "John@lewagon.com", password: "12345678")


### PR DESCRIPTION
On the profile page the NFTs that belong to the user have an edit button instead of a show button. This links to the edit page so the user can change the details
![Screenshot 2022-02-25 at 08 49 29](https://user-images.githubusercontent.com/96726657/155685065-84e62505-3540-4296-bb99-f370abe61375.png)
